### PR TITLE
ARCH-1916 - Adding a checkout to the increment

### DIFF
--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -1,5 +1,5 @@
 name: Increment Version on Merge
-run-name: 'Increment Version for PR #${{ github.event.pull_request.number }}'
+run-name: "${{ github.event.pull_request.merged && 'Increment version for' || 'Closing' }} PR #${{ github.event.pull_request.number }}"
 on:
   # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
   # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
@@ -58,6 +58,9 @@ jobs:
             }
             console.log(`PR is merged to ${defaultBranch}.  Proceed with subsequent steps.`);
             core.exportVariable('MERGE_TO_MAIN', true);
+
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: If PR is merged to main - Check for code changes to the action source code
         if: env.MERGE_TO_MAIN == 'true'


### PR DESCRIPTION
# Summary of PR changes
- Add a checkout to the increment workflow.  This is necessary since it is using itself in the workflow.


## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
