### PR TITLE
ARCH-1919 - Add env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This action is intended to be used in the same repo where the PRs are created an
 
 - [did-custom-action-code-change](#did-custom-action-code-change)
   - [Inputs](#inputs)
-  - [Outputs](#outputs)
+  - [Outputs and Environment Variables](#outputs-and-environment-variables)
   - [Usage Examples](#usage-examples)
   - [Contributing](#contributing)
     - [Incrementing the Version](#incrementing-the-version)
@@ -28,7 +28,7 @@ This action is intended to be used in the same repo where the PRs are created an
 | `folders-with-code` | false       | N/A     | A comma separated list of folders with code to check for changes. |
 | `token`             | true        | N/A     | A token with permission to retrieve PR information.               |
 
-## Outputs
+## Outputs and Environment Variables
 
 | Output        | Description                                                                   |
 |---------------|-------------------------------------------------------------------------------|
@@ -49,14 +49,14 @@ jobs:
       - name: Check for code changes to the action
         id: action-code
         # You may also reference just the major or major.minor version
-        uses: im-open/did-custom-action-code-change@v1.0.2
+        uses: im-open/did-custom-action-code-change@v1.0.3
         with:
           files-with-code: 'action.yml,package.json,package-lock.json'
           folders-with-code: 'src,dist'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit unstaged changes if there are code changes
-        if: steps.action-code.outputs.HAS_CHANGES == 'true'
+        if: steps.action-code.outputs.HAS_CHANGES == 'true' # can also use env.HAS_CHANGES
         run: |
           if [[ "$(git status --porcelain)" != "" ]]; then
             git add .

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ This action is intended to be used in the same repo where the PRs are created an
 
 ## Outputs and Environment Variables
 
-| Output        | Description                                                                   |
-|---------------|-------------------------------------------------------------------------------|
-| `HAS_CHANGES` | Flag indicating whether changes were found in the code files or code folders. |
+| Output                 | Description                                                                   |
+|------------------------|-------------------------------------------------------------------------------|
+| `outputs.HAS_CHANGES`  | Flag indicating whether changes were found in the code files or code folders. |
+| `env.CODE_HAS_CHANGED` | Flag indicating whether changes were found in the code files or code folders. |
 
 ## Usage Examples
 
@@ -56,7 +57,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit unstaged changes if there are code changes
-        if: steps.action-code.outputs.HAS_CHANGES == 'true' # can also use env.HAS_CHANGES
+        if: steps.action-code.outputs.HAS_CHANGES == 'true' # can also use env.CODE_HAS_CHANGED
         run: |
           if [[ "$(git status --porcelain)" != "" ]]; then
             git add .

--- a/dist/index.js
+++ b/dist/index.js
@@ -16632,7 +16632,7 @@ async function run() {
   const matchingFolders = foldersToCheckForChanges.filter(f => foldersChangedInPr.includes(f)) || [];
   const hasMatchingChanges = matchingFiles.length > 0 || matchingFolders.length > 0;
   core.setOutput('HAS_CHANGES', hasMatchingChanges);
-  core.exportVariable('HAS_CHANGES', hasMatchingChanges);
+  core.exportVariable('CODE_HAS_CHANGED', hasMatchingChanges);
 }
 run();
 /*!

--- a/dist/index.js
+++ b/dist/index.js
@@ -16632,6 +16632,7 @@ async function run() {
   const matchingFolders = foldersToCheckForChanges.filter(f => foldersChangedInPr.includes(f)) || [];
   const hasMatchingChanges = matchingFiles.length > 0 || matchingFolders.length > 0;
   core.setOutput('HAS_CHANGES', hasMatchingChanges);
+  core.exportVariable('HAS_CHANGES', hasMatchingChanges);
 }
 run();
 /*!

--- a/src/main.js
+++ b/src/main.js
@@ -53,6 +53,7 @@ async function run() {
   const hasMatchingChanges = matchingFiles.length > 0 || matchingFolders.length > 0;
 
   core.setOutput('HAS_CHANGES', hasMatchingChanges);
+  core.exportVariable('HAS_CHANGES', hasMatchingChanges);
 }
 
 run();

--- a/src/main.js
+++ b/src/main.js
@@ -53,7 +53,7 @@ async function run() {
   const hasMatchingChanges = matchingFiles.length > 0 || matchingFolders.length > 0;
 
   core.setOutput('HAS_CHANGES', hasMatchingChanges);
-  core.exportVariable('HAS_CHANGES', hasMatchingChanges);
+  core.exportVariable('CODE_HAS_CHANGED', hasMatchingChanges);
 }
 
 run();


### PR DESCRIPTION
# Summary of PR changes

This should reduce extra steps when I want to use the tagged version and local version in the reusable workflows.  

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
